### PR TITLE
Fix typo

### DIFF
--- a/src/parsers/event/jsonApiToJson.js
+++ b/src/parsers/event/jsonApiToJson.js
@@ -23,7 +23,7 @@ function jsonApiToJson(req, res, next) {
 
         for (let key in eventAttributes) {
             if (eventAttributes.hasOwnProperty(key)) {
-                if (key.startsWith('X-')) {
+                if (key.startsWith('x-')) {
                     if (!json['x_fields'])
                         json['x_fields'] = {};
                     json['x_fields'][key] = eventAttributes[key];


### PR DESCRIPTION
As written in your swagger-doc, the x_fields has to start with "x-"
https://schul-cloud.github.io/schulcloud-calendar/#!/events/post_events